### PR TITLE
Ignore DVT build config dicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ gradle-app.setting
 # DVT
 .dvt/*.ls
 .dvt/build.config.xml
+.dvt/.build_config_dict/


### PR DESCRIPTION
These started showing up with newer DVT versions. No idea what they are, but they are binary files.